### PR TITLE
Fix linting errors

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,11 @@
+# Solace Application Recommended Improvements
+
+## 1. Fix basic errors in initial React app
+
+First things first, let's fix up basic linting errors, TypeScript errors, and general bad practices in a React app. While these are often small issues that could be ignored, it's extremely important to set a good tone when scaffolding an app. Some examples of issues that should be fixed:
+
+1. Let's avoid using DOM manipulation - There is a call to document.getElementById, let's use React for this
+2. Let's make sure that we have a key any time we iterate over something -- Currently, the BE doesn't deliver a good key, but we can at least make a quick composite key. This isn't ideal and we will fix it later, but we don't want to risk missing a re-render because of key issues
+3. Fix runtime typing errors - Currently, these are runtime errors instead of compile-time errors, which we will fix shortly, but it's important to make sure the app is functional after each PR
+   1. yearsOfExperience is a number but we call includes on it
+   2. We will convert this to a string for now, but you can see how this whole functionality is weird

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,25 +58,29 @@ export default function Home() {
       <br />
       <table>
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>City</th>
+            <th>Degree</th>
+            <th>Specialties</th>
+            <th>Years of Experience</th>
+            <th>Phone Number</th>
+          </tr>
         </thead>
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
+              <tr
+                key={`${advocate.firstName}-${advocate.lastName}-${advocate.phoneNumber}`}
+              >
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={s}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 export default function Home() {
+  const [searchTerm, setSearchTerm] = useState("");
   const [advocates, setAdvocates] = useState([]);
   const [filteredAdvocates, setFilteredAdvocates] = useState([]);
 
@@ -17,23 +18,22 @@ export default function Home() {
   }, []);
 
   const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
+    const searchTermInput = e.target.value;
 
     console.log("filtering advocates...");
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
+        advocate.firstName.includes(searchTermInput) ||
+        advocate.lastName.includes(searchTermInput) ||
+        advocate.city.includes(searchTermInput) ||
+        advocate.degree.includes(searchTermInput) ||
+        advocate.specialties.includes(searchTermInput) ||
+        advocate.yearsOfExperience.toString().includes(searchTermInput)
       );
     });
 
     setFilteredAdvocates(filteredAdvocates);
+    setSearchTerm(searchTermInput);
   };
 
   const onClick = () => {
@@ -49,7 +49,7 @@ export default function Home() {
       <div>
         <p>Search</p>
         <p>
-          Searching for: <span id="search-term"></span>
+          Searching for: <span>{searchTerm}</span>
         </p>
         <input style={{ border: "1px solid black" }} onChange={onChange} />
         <button onClick={onClick}>Reset Search</button>


### PR DESCRIPTION
The first PR in this series is a quick little one to fix up some linting errors. These are little things that are pretty easy to fix, but if you let them sit in your code base for long enough, they will get real pervasive and bad habits will fester throughout your application as developers copy and paste between files.

This addresses the following issues:

1. An HTML syntax error -- th elements need to be inside of a tr element
2. Whenever we iterate in React, we need to have a key. This problem can be especially pervasive since the bugs it causes are not immediately obvious to the developer. Eventually, though, we will add the ability to sort or otherwise manipulate the table, and the lack of a key could cause erroneous rows to be displayed or for unnecessary renders to be performed
3. Removed the usage of document.getElementById. This is a common technique used by developers who aren't "thinking in React". We want to perform our business logic and our view logic and let React do the work for us. In this case, we pulled the search term into a state variable and "react" to it in order to display it in the application