### PR TITLE
Refactor backend to use a layered architecture

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -42,4 +42,7 @@ First things first, let's fix up basic linting errors, TypeScript errors, and ge
 1. Now that the frontend has been cleaned up, we will focus on improving the backend.
 2. We did a great thing of having a working backend first, which allowed us to make a bunch of improvements to the FE without being blocked by backend work
 3. The first improvement to make is pagination and limiting payloads...this is a huge deal and you never want to see an app without these. We will add pagination options and enforce a hard limit of 100 records per api request
+4. Next, we split "route.js" into 3 more files: a controller (handles client communications), a service (handles business logic), and a repository (handles persistence)
+5. This enabled us to test our app much more easily
+   1. A common excuse for a lack of testing is "everything is so intertwined". Well, now it isn't. Even if we theoretically had difficult testing the database or API, we still have tests of our business logic in the service file. In this case, we don't do much except calculate the cursor (which could become middleware in the future) but business logic will balloon as the project becomes more mature
   

--- a/src/app/api/advocates/controller.test.ts
+++ b/src/app/api/advocates/controller.test.ts
@@ -1,0 +1,121 @@
+import { getAdvocatesController } from "./controller";
+import { getAdvocates } from "./service";
+
+jest.mock("./service");
+
+describe("getAdvocatesController", () => {
+  const mockGetAdvocates = getAdvocates as jest.Mock;
+
+  global.Response = class {
+    status: number;
+    
+    static json(data: any) {
+      return {
+        status: 200,
+        json: async () => data,
+        text: async () => JSON.stringify(data),
+      };
+    }
+
+    constructor(public body: string, public init: { status: number }) {
+      this.status = init.status;
+    }
+
+    async text() {
+      return this.body;
+    }
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns advocates and nextCursor when data is available", async () => {
+    const mockRequest = {
+      url: "http://localhost/api/advocates?cursor=0&limit=10",
+    };
+    const mockData = [
+      { id: 1, name: "Advocate 1" },
+      { id: 2, name: "Advocate 2" },
+    ];
+    mockGetAdvocates.mockResolvedValue({ data: mockData, nextCursor: 2 });
+
+    const response = await getAdvocatesController(mockRequest as any);
+    const jsonResponse = await response.json();
+
+    expect(mockGetAdvocates).toHaveBeenCalledWith(0, 10);
+    expect(response.status).toBe(200);
+    expect(jsonResponse).toEqual({
+      data: mockData,
+      nextCursor: 2,
+    });
+  });
+
+  it("returns an empty array and null nextCursor when no data is available", async () => {
+    const mockRequest = {
+      url: "http://localhost/api/advocates?cursor=0&limit=10",
+    };
+    mockGetAdvocates.mockResolvedValue({ data: [], nextCursor: null });
+
+    const response = await getAdvocatesController(mockRequest as any);
+    const jsonResponse = await response.json();
+
+    expect(mockGetAdvocates).toHaveBeenCalledWith(0, 10);
+    expect(response.status).toBe(200);
+    expect(jsonResponse).toEqual({
+      data: [],
+      nextCursor: null,
+    });
+  });
+
+  it("handles errors thrown by the service", async () => {
+    const mockRequest = {
+      url: "http://localhost/api/advocates?cursor=0&limit=10",
+    };
+    mockGetAdvocates.mockRejectedValue(new Error("Service error"));
+
+    const response = await getAdvocatesController(mockRequest as any);
+
+    expect(mockGetAdvocates).toHaveBeenCalledWith(0, 10);
+    console.log(response);
+    expect(response.status).toBe(500);
+    const textResponse = await response.text();
+    expect(textResponse).toBe("Service error");
+  });
+
+  it("parses query parameters correctly", async () => {
+    const mockRequest = {
+      url: "http://localhost/api/advocates?cursor=5&limit=20",
+    };
+    const mockData = [{ id: 6, name: "Advocate 6" }];
+    mockGetAdvocates.mockResolvedValue({ data: mockData, nextCursor: 6 });
+
+    const response = await getAdvocatesController(mockRequest as any);
+    const jsonResponse = await response.json();
+
+    expect(mockGetAdvocates).toHaveBeenCalledWith(5, 20);
+    expect(response.status).toBe(200);
+    expect(jsonResponse).toEqual({
+      data: mockData,
+      nextCursor: 6,
+    });
+  });
+
+  it("defaults limit to 100 if not provided", async () => {
+    const mockRequest = {
+      url: "http://localhost/api/advocates?cursor=0",
+    };
+    const mockData = [{ id: 1, name: "Advocate 1" }];
+    mockGetAdvocates.mockResolvedValue({ data: mockData, nextCursor: 1 });
+
+    const response = await getAdvocatesController(mockRequest as any);
+    const jsonResponse = await response.json();
+
+    expect(mockGetAdvocates).toHaveBeenCalledWith(0, 100);
+    expect(response.status).toBe(200);
+    expect(jsonResponse).toEqual({
+      data: mockData,
+      nextCursor: 1,
+    });
+  });
+});

--- a/src/app/api/advocates/controller.ts
+++ b/src/app/api/advocates/controller.ts
@@ -1,0 +1,14 @@
+import { getAdvocates } from "./service";
+
+export async function getAdvocatesController(request: Request) {
+  const url = new URL(request.url);
+  const cursor = parseInt(url.searchParams.get("cursor") ?? "0", 10);
+  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "100"), 100);
+
+  try {
+    const { data, nextCursor } = await getAdvocates(cursor, limit);
+    return Response.json({ data, nextCursor });
+  } catch (error) {
+    return new Response(error.message, { status: 500 });
+  }
+}

--- a/src/app/api/advocates/controller.ts
+++ b/src/app/api/advocates/controller.ts
@@ -3,7 +3,10 @@ import { getAdvocates } from "./service";
 export async function getAdvocatesController(request: Request) {
   const url = new URL(request.url);
   const cursor = parseInt(url.searchParams.get("cursor") ?? "0", 10);
-  const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "100"), 100);
+  const limit = Math.max(
+    Math.min(parseInt(url.searchParams.get("limit") ?? "100"), 100),
+    0
+  );
 
   try {
     const { data, nextCursor } = await getAdvocates(cursor, limit);

--- a/src/app/api/advocates/repository.test.ts
+++ b/src/app/api/advocates/repository.test.ts
@@ -1,0 +1,67 @@
+import { fetchAdvocates } from "./repository";
+import db from "../../../db";
+import { advocates } from "../../../db/schema";
+import { gt } from "drizzle-orm";
+
+jest.mock("../../../db", () => ({
+  select: jest.fn(() => ({
+    from: jest.fn(() => ({
+      limit: jest.fn(() => ({
+        where: jest.fn(),
+      })),
+    })),
+  })),
+}));
+
+describe("fetchAdvocates", () => {
+  const mockQuery = {
+    from: jest.fn(),
+    limit: jest.fn(),
+    where: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.select as jest.Mock).mockReturnValue(mockQuery);
+    mockQuery.from.mockReturnValue(mockQuery);
+    mockQuery.limit.mockReturnValue(mockQuery);
+    mockQuery.where.mockReturnValue(mockQuery);
+  });
+
+  it("fetches advocates without a cursor", async () => {
+    const mockData = [{ id: 1, name: "Test Advocate" }];
+    mockQuery.limit.mockResolvedValue(mockData);
+
+    const result = await fetchAdvocates(0, 10);
+
+    expect(db.select).toHaveBeenCalled();
+    expect(mockQuery.from).toHaveBeenCalledWith(advocates);
+    expect(mockQuery.limit).toHaveBeenCalledWith(10);
+    expect(mockQuery.where).not.toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it("fetches advocates with a cursor", async () => {
+    const mockData = [{ id: 2, name: "Another Advocate" }];
+    mockQuery.where.mockResolvedValue(mockData);
+
+    const result = await fetchAdvocates(1, 10);
+
+    expect(db.select).toHaveBeenCalled();
+    expect(mockQuery.from).toHaveBeenCalledWith(advocates);
+    expect(mockQuery.limit).toHaveBeenCalledWith(10);
+    expect(mockQuery.where).toHaveBeenCalledWith(gt(advocates.id, 1));
+    expect(result).toEqual(mockData);
+  });
+
+  it("returns an empty array if no advocates are found", async () => {
+    mockQuery.limit.mockResolvedValue([]);
+
+    const result = await fetchAdvocates(0, 10);
+
+    expect(db.select).toHaveBeenCalled();
+    expect(mockQuery.from).toHaveBeenCalledWith(advocates);
+    expect(mockQuery.limit).toHaveBeenCalledWith(10);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/app/api/advocates/repository.ts
+++ b/src/app/api/advocates/repository.ts
@@ -1,0 +1,13 @@
+import { gt } from "drizzle-orm";
+import db from "../../../db";
+import { advocates } from "../../../db/schema";
+
+export async function fetchAdvocates(cursor: number, limit: number) {
+  let query = db.select().from(advocates).limit(limit);
+
+  if (cursor) {
+    query = query.where(gt(advocates.id, cursor));
+  }
+
+  return await query;
+}

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,23 +1,5 @@
-import { gt } from "drizzle-orm";
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
+import { getAdvocatesController } from "./controller";
 
 export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const searchParams = url.searchParams;
-
-  const cursor = parseInt(searchParams.get("cursor") ?? "", 10);
-  const limit = Math.min(parseInt(searchParams.get("limit") ?? "100"), 100);
-
-  let query = db.select().from(advocates).limit(limit).offset(0);
-
-  if (cursor) {
-    query = query.where(cursor ? gt(advocates.id, cursor) : undefined);
-  }
-
-  const data = await query;
-
-  const nextCursor = data.length > 0 ? data[data.length - 1].id : null;
-
-  return Response.json({ data, nextCursor });
+  return getAdvocatesController(request);
 }

--- a/src/app/api/advocates/service.test.ts
+++ b/src/app/api/advocates/service.test.ts
@@ -1,0 +1,48 @@
+import { getAdvocates } from "./service";
+import { fetchAdvocates } from "./repository";
+
+jest.mock("./repository");
+
+describe("getAdvocates", () => {
+  const mockFetchAdvocates = fetchAdvocates as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns advocates and the next cursor when data is available", async () => {
+    const mockData = [
+      { id: 1, name: "Advocate 1" },
+      { id: 2, name: "Advocate 2" },
+    ];
+    mockFetchAdvocates.mockResolvedValue(mockData);
+
+    const result = await getAdvocates(0, 10);
+
+    expect(mockFetchAdvocates).toHaveBeenCalledWith(0, 10);
+    expect(result).toEqual({
+      data: mockData,
+      nextCursor: 2, // Last item's ID
+    });
+  });
+
+  it("returns an empty array and null next cursor when no data is available", async () => {
+    mockFetchAdvocates.mockResolvedValue([]);
+
+    const result = await getAdvocates(0, 10);
+
+    expect(mockFetchAdvocates).toHaveBeenCalledWith(0, 10);
+    expect(result).toEqual({
+      data: [],
+      nextCursor: null,
+    });
+  });
+
+  it("handles errors thrown by the repository", async () => {
+    mockFetchAdvocates.mockRejectedValue(new Error("Database error"));
+
+    await expect(getAdvocates(0, 10)).rejects.toThrow("Database error");
+
+    expect(mockFetchAdvocates).toHaveBeenCalledWith(0, 10);
+  });
+});

--- a/src/app/api/advocates/service.ts
+++ b/src/app/api/advocates/service.ts
@@ -1,0 +1,9 @@
+import { fetchAdvocates } from "./repository";
+
+export async function getAdvocates(cursor: number, limit: number) {
+  const data = await fetchAdvocates(cursor, limit);
+
+  const nextCursor = data.length > 0 ? data[data.length - 1].id : null;
+
+  return { data, nextCursor };
+}


### PR DESCRIPTION
I'm a big believer in separating your application horizontally (into different layers, i.e. business logic, persistence, view) and vertically (into domains, i.e. just advocates in this case). Not only does this make your code a lot easier to test, but it also reduces the mental load on developers when they are designing new feature work. All you really need to do is figure out what box each bit of logic should go in, and the code will practically write itself.

In this case, we of course only have a single domain called advocates. In the future, we could add more domains, or perhaps fold advocates into a new domain with some other entity. Our setup is quite flexible so we can make any changes we need to. We also have 3 main layers:

1. Presentation -- This handles the controller & view, essentially taking the client input and mapping it to actions in our system, and then mapping the results of that back into what the client expects. Ours is pretty thin, but we would have a ton more in the future as we implement filtering
2. Domain -- This handles our business logic, which again is quite small at this stage. All we really do is fetch advocates and make sure we have a pointer to the next one (which could debateably be in the persistence layer)
3. Persistence -- This layer talks to the database and ensures that our records are persisted properly and deserialized correctly. Separating this out allows us to test our business logic without setting up a whole database

Finally, I added backend tests for each of these layers. If you are reviewing this PR, spend most of your time reviewing the tests. Because of the separation, it was very easy to test each and every important step in loading this data for our user